### PR TITLE
Message logging for Hiboutik Sync

### DIFF
--- a/woocommerce-hiboutik.php
+++ b/woocommerce-hiboutik.php
@@ -41,7 +41,7 @@ function fromHiboutik( $query )
 				hiboutikLog("La gestion de stock pour produit {$item['product_id']} est désactivée dans WooCommerce.");
 			}
 			wc_update_product_stock($wc_prod_id, $wc_stock - $item['quantity']);
-			hiboutikLog("Le stock du produit {$wc_prod_id} reduit de {$item['quantity']} avec succes.");
+			hiboutikLog("Le stock du produit {$wc_prod_id} reduit de {$item['quantity']} avec succès.");
 		}
 		exit();
 	}


### PR DESCRIPTION
Add message logging system for synchronisation.

Logging is defined by HIBOUTIK_LOG ( bolean; default false ) and listens to HIBOUTIK_LOG_MAIL ( bolean or string: email address; default not set ) and can log to file wp-content/hiboutik.log or to email sent to address given or site admin address.

Fixes issue #1