### PR TITLE
Fix typo in example code to add payment method

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ with this :
 ```php
 
       //Set payment method
-      $hibou_set_payment = $hiboutik->put("/sales/$hibou_sale_id/", [
+      $hibou_set_payment = $hiboutik->put("/sale/$hibou_sale_id/", [
       'sale_attribute'  => 'payment',
       'new_value'       => 'XXX'
       ]);


### PR DESCRIPTION
The REST API method is /sale/$id/, not /sales/$id. This caused the code to silently not function.